### PR TITLE
Load configuration from .reek.yml

### DIFF
--- a/lib/solargraph-reek.rb
+++ b/lib/solargraph-reek.rb
@@ -6,6 +6,7 @@ module Solargraph
   module Reek
     class Reporter < Solargraph::Diagnostics::Base
       def diagnose source, _api_map
+        Reek::Configuration::ConfigurationFileFinder.find_and_load
         examiner = ::Reek::Examiner.new(source.code.dup)
         examiner.smells.map { |w| warning_to_diagnostic(w) }
       rescue ::Reek::Errors::SyntaxError

--- a/lib/solargraph-reek.rb
+++ b/lib/solargraph-reek.rb
@@ -6,8 +6,8 @@ module Solargraph
   module Reek
     class Reporter < Solargraph::Diagnostics::Base
       def diagnose source, _api_map
-        Reek::Configuration::ConfigurationFileFinder.find_and_load
-        examiner = ::Reek::Examiner.new(source.code.dup)
+        configuration = ::Reek::Configuration::AppConfiguration.from_default_path
+        examiner = ::Reek::Examiner.new(source.code.dup, configuration: configuration)
         examiner.smells.map { |w| warning_to_diagnostic(w) }
       rescue ::Reek::Errors::SyntaxError
         []

--- a/lib/solargraph-reek/version.rb
+++ b/lib/solargraph-reek/version.rb
@@ -1,5 +1,5 @@
 module Solargraph
   module Reek
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
The plugin is currently not loading the config from a `.reek.yml` you may have in your project. Looking at Reek's source I found the method `::Reek::Configuration::AppConfiguration.from_default_path`.

I tested locally and it worked.