### PR TITLE
Full support for Reek configuration files

### DIFF
--- a/lib/solargraph-reek.rb
+++ b/lib/solargraph-reek.rb
@@ -9,6 +9,8 @@ module Solargraph
         configuration = ::Reek::Configuration::AppConfiguration.from_default_path
         source_pathname = Pathname.new(source.filename)
 
+        return [] if configuration.path_excluded?(source_pathname)
+
         examiner = ::Reek::Examiner.new(source_pathname, configuration: configuration)
         examiner.smells.map { |w| warning_to_diagnostic(w) }
       rescue ::Reek::Errors::SyntaxError

--- a/lib/solargraph-reek.rb
+++ b/lib/solargraph-reek.rb
@@ -6,6 +6,7 @@ module Solargraph
   module Reek
     class Reporter < Solargraph::Diagnostics::Base
       def diagnose source, _api_map
+        Reek::Configuration::ConfigurationFileFinder.find_and_load
         examiner = ::Reek::Examiner.new(source.code.dup)
         examiner.smells.map { |w| warning_to_diagnostic(w) }
       rescue ::Reek::Errors::SyntaxError

--- a/lib/solargraph-reek.rb
+++ b/lib/solargraph-reek.rb
@@ -6,8 +6,8 @@ module Solargraph
   module Reek
     class Reporter < Solargraph::Diagnostics::Base
       def diagnose source, _api_map
-        Reek::Configuration::ConfigurationFileFinder.find_and_load
-        examiner = ::Reek::Examiner.new(source.code.dup)
+        configuration = ::Reek::Configuration::AppConfiguration.from_default_path
+        examiner = ::Reek::Examiner.new(source.code.dup, configuration: configuration)
         examiner.smells.map { |w| warning_to_diagnostic(w) }
       rescue ::Reek::Errors::SyntaxError
         []

--- a/lib/solargraph-reek.rb
+++ b/lib/solargraph-reek.rb
@@ -1,6 +1,7 @@
 require 'solargraph'
 require 'solargraph-reek/version'
 require 'reek'
+require 'pathname'
 
 module Solargraph
   module Reek

--- a/lib/solargraph-reek.rb
+++ b/lib/solargraph-reek.rb
@@ -5,9 +5,11 @@ require 'reek'
 module Solargraph
   module Reek
     class Reporter < Solargraph::Diagnostics::Base
-      def diagnose source, _api_map
+      def diagnose(source, _api_map)
         configuration = ::Reek::Configuration::AppConfiguration.from_default_path
-        examiner = ::Reek::Examiner.new(source.code.dup, configuration: configuration)
+        source_pathname = Pathname.new(source.filename)
+
+        examiner = ::Reek::Examiner.new(source_pathname, configuration: configuration)
         examiner.smells.map { |w| warning_to_diagnostic(w) }
       rescue ::Reek::Errors::SyntaxError
         []

--- a/lib/solargraph-reek/version.rb
+++ b/lib/solargraph-reek/version.rb
@@ -1,5 +1,5 @@
 module Solargraph
   module Reek
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
I tested and can confirm that the patches from @parruda (https://github.com/castwide/solargraph-reek/pull/1) and @edward-mb  (https://github.com/castwide/solargraph-reek/pull/2) work.

#1 supports only the `detectors` configuration option. #2 adds support for the `directories` configuration option.

However, the support for the `exclude_paths` configuration option is still missing.

This pull request is based on #1 and #2 and adds support for the `exclude_paths` configuration option.